### PR TITLE
Fixed building on HaikuOS.

### DIFF
--- a/protocols/oscar/src/oscarauth.cpp
+++ b/protocols/oscar/src/oscarauth.cpp
@@ -23,6 +23,11 @@
 **
 ****************************************************************************/
 
+#include <qglobal.h>
+#ifdef Q_OS_HAIKU
+# define SHA2_TYPES
+#endif
+
 #include "oscarauth.h"
 #include "icqaccount.h"
 #include "oscarconnection.h"


### PR DESCRIPTION
Fixed problem with building icq plugin on Haiku OS. Thanks to EuroElessar.
