### PR TITLE
Leave contact's name unchanged if rename dialog was cancelled

### DIFF
--- a/core/src/corelayers/simpleactions/src/simpleactions.cpp
+++ b/core/src/corelayers/simpleactions/src/simpleactions.cpp
@@ -155,11 +155,16 @@ void SimpleActions::onCopyIdTriggered(QObject *obj)
 void SimpleActions::onContactRenameAction(QObject *o)
 {
 	Contact *contact = sender_cast<Contact*>(o);
+
+	bool ok;
 	QString result = QInputDialog::getText(QApplication::activeWindow(), tr("Rename contact %1").arg(contact->title()),
 										   tr("Input new name for contact %1").arg(contact->title()),
 										   QLineEdit::Normal,
-										   contact->name());
-	contact->setName(result);
+										   contact->name(),
+										   &ok);
+
+	if(ok)
+		contact->setName(result);
 }
 
 void SimpleActions::onShowInfoAction(QObject *obj)


### PR DESCRIPTION
There's a little bug in renaming contact: if cancel dialog with any string, it returns empty one and qutim renames contact to it. So now in this case it leaves as is.
