### PR TITLE
Underlinking

### DIFF
--- a/core/libqutim/CMakeLists.txt
+++ b/core/libqutim/CMakeLists.txt
@@ -134,7 +134,7 @@ ENDIF()
 
 
 # Link with Qt
-qutim_target_link_libraries( libqutim ${QT_LIBRARIES} ${EXTRA_LIBS})
+qutim_target_link_libraries( libqutim ${QT_LIBRARIES} ${X11_LIBRARIES} ${EXTRA_LIBS})
 
 install( TARGETS libqutim 
 	RUNTIME DESTINATION bin


### PR DESCRIPTION
Build fails with the gold linker due to underlinking. This commit adds the missing library.
