### PR TITLE
Исправлен баг "используется неизвестный для fopen флаг открытия файла лога"

### DIFF
--- a/plugins/logger/src/logger.cpp
+++ b/plugins/logger/src/logger.cpp
@@ -124,7 +124,7 @@ void LoggerPlugin::reloadSettings()
 			logfile = fopen(path.toLocal8Bit(), "w");
 //			logfile.open(path.toLocal8Bit(), ios::out | ios::trunc);
 		else
-			logfile = fopen(path.toLocal8Bit(), "wa");
+			logfile = fopen(path.toLocal8Bit(), "a");
 //			logfile.open(path.toLocal8Bit(), ios::app);
 	} else if (!enable && logfile) {
 		fflush(logfile);


### PR DESCRIPTION
Передавался некорректный флаг для открытия файла лога
Баг можно поймать при сборке дебаг версии (получаем assert из fopen)
