### PR TITLE
Включает отображение даты в окне просмотра истории

### DIFF
--- a/core/src/corelayers/jsonhistory/historywindow.cpp
+++ b/core/src/corelayers/jsonhistory/historywindow.cpp
@@ -458,7 +458,7 @@ void HistoryWindow::on_dateTreeWidget_currentItemChanged( QTreeWidgetItem* curre
 								cursor.insertText(sender.toString());
 							}
 							cursor.insertText(QLatin1Literal(" (")
-											  % history_date_time.time().toString()
+											  % history_date_time.toString("dd.MM.yyyy hh:mm:ss")
 											  % QLatin1Literal(")"));
 							cursor.setCharFormat(defaultFont);
 							cursor.insertText(newLine);


### PR DESCRIPTION
Включает отображение даты в окне просмотра истории в формате "(dd.MM.yyyy hh:mm:ss)" вместо использовавшегося ранее "(hh:mm:ss)"
Теперь при копировании из истории однозначно будет видно дату цитируемого разговора
