### PR TITLE
Disable reconnect for error: "Another client is loggin with this uin"

### DIFF
--- a/protocols/oscar/src/icqaccount.cpp
+++ b/protocols/oscar/src/icqaccount.cpp
@@ -248,6 +248,9 @@ void IcqAccount::setStatus(Status status_helper)
 		} else if (d->conn->error() == AbstractConnection::RateLimitExceeded) {
 			status.setChangeReason(Status::ByNetworkError);
 			status.setProperty("reconnectTimeout", 1200);
+		} else if (d->conn->error() == AbstractConnection::AnotherClientLogined) {
+			// Disable reconnecting
+			status.setChangeReason(Status::ByUser);
 		} else {
 			status.setChangeReason(Status::ByFatalError);
 		}


### PR DESCRIPTION
ICQ allows multiple connections but you may want to reset other logins by sending a message "1" to system aol contact "aolsystemmsg"
