### PR TITLE
Indicator patch for Ubuntu 12.10

### DIFF
--- a/plugins/indicator/CMakeLists.txt
+++ b/plugins/indicator/CMakeLists.txt
@@ -1,19 +1,26 @@
 ADD_DEFINITIONS( -DDESKTOPDIR="${CMAKE_INSTALL_PREFIX}/share/applications" )
 FIND_PACKAGE(PkgConfig)
-pkg_check_modules(INDICATE indicate>=0.2.1)
-pkg_check_modules(INDICATEQT indicate-qt>=0.2.2)
-if( NOT INDICATEQT_FOUND )
-	message( "IndicateQt not found. Can't build indicator" )
-	return()
-endif( NOT INDICATEQT_FOUND )
+pkg_check_modules(MMENU libmessaging-menu-qt>=12.10)
+if(NOT MMENU_FOUND)
+    pkg_check_modules(INDICATE indicate>=0.2.1)
+    pkg_check_modules(INDICATEQT indicate-qt>=0.2.2)
+    if( NOT INDICATEQT_FOUND )
+        message( "IndicateQt not found. Can't build indicator" )
+        return()
+    endif()
+else()
+    ADD_DEFINITIONS( -DQUANTAL=1 )
+endif()
 
 INCLUDE_DIRECTORIES(
 	${INDICATE_INCLUDE_DIRS}
 	${INDICATEQT_INCLUDE_DIRS}
+    ${MMENU_INCLUDE_DIRS}
 	)
 LINK_DIRECTORIES(
 	${INDICATE_LIBRARY_DIRS}
 	${INDICATEQT_LIBRARY_DIRS}
+    ${MMENU_LIBRARY_DIRS}
 	)
 
 FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/qutim ${CMAKE_INSTALL_PREFIX}/share/applications/qutim.desktop)
@@ -24,5 +31,5 @@ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/qutim DESTINATION
 qutim_add_plugin( indicator
 	DISPLAY_NAME "Indicator"
 	DESCRIPTION "Ubuntu Indicator applet integration"
-	LINK_LIBRARIES ${INDICATE_LIBRARIES} ${INDICATEQT_LIBRARIES}
+    LINK_LIBRARIES ${INDICATE_LIBRARIES} ${INDICATEQT_LIBRARIES} ${MMENU_LIBRARIES}
 )

--- a/plugins/indicator/src/indicatorservice.cpp
+++ b/plugins/indicator/src/indicatorservice.cpp
@@ -31,41 +31,59 @@
 #include <QDateTime>
 #include <QApplication>
 
-IndicatorService::IndicatorService() :
-	desktopName( QUTIM_DESKTOP_FILE ),
-	indicateServer(QIndicate::Server::defaultInstance()),
-	quitButton(new QIndicate::Indicator)
+IndicatorService::IndicatorService()
+#ifdef QUANTAL
+    : desktopName( QUTIM_DESKTOP_BASENAME )
+    , indicateServer(new Server(desktopName, this))
+    , quitButton(&indicateServer->createSourceString(QLatin1String("quitButton"), QT_TRANSLATE_NOOP("Plugin", "Close qutIM"), qutim_sdk_0_3::Icon("application-exit"), ""))
+#else /* QUANTAL */
+	: desktopName( QUTIM_DESKTOP_FILE )
+	, indicateServer(Server::defaultInstance())
+	, quitButton(new Source)
+#endif /* QUANTAL */
 {
+#ifdef QUANTAL
+    indicateServer->registerApp();
+	connect(indicateServer, SIGNAL(sourceActivated(MessagingMenu::Application::Source&)),
+	        SLOT(onIndicatorDisplay(MessagingMenu::Application::Source&)));
+#else /* QUANTAL */
 	indicateServer->setType("message.im");
 	indicateServer->setDesktopFile(desktopName);
 	indicateServer->show();
 	connect(indicateServer, SIGNAL(serverDisplay()), SLOT(showMainWindow()));
+#endif /* QUANTAL */
 	connect(qutim_sdk_0_3::ChatLayer::instance(), SIGNAL(sessionCreated(qutim_sdk_0_3::ChatSession*)), SLOT(onSessionCreated(qutim_sdk_0_3::ChatSession*)));
 
 	//QImage icon = qutim_sdk_0_3::Icon("qutim").pixmap(64).toImage();
-	
+
 	qApp->setQuitOnLastWindowClosed(false);
 
 	/* Quit Button */
+#ifndef QUANTAL
 	quitButton->setNameProperty(QT_TRANSLATE_NOOP("Plugin", "Close qutIM"));
 	QImage icon = qutim_sdk_0_3::Icon("application-exit").pixmap(64).toImage();
 	connect(quitButton, SIGNAL(display(QIndicate::Indicator*)), qApp, SLOT(quit()));
 	quitButton->setIconProperty(icon);
 	quitButton->show();
+#endif /* QUANTAL */
 	foreach (qutim_sdk_0_3::ChatSession *session, qutim_sdk_0_3::ChatLayer::instance()->sessions())
 		onSessionCreated(session);
 }
 
 IndicatorService::~IndicatorService()
 {
+	disconnect(qutim_sdk_0_3::ChatLayer::instance(), SIGNAL(sessionCreated(qutim_sdk_0_3::ChatSession*)),
+	           this, SLOT(onSessionCreated(qutim_sdk_0_3::ChatSession*)));
+#ifdef QUANTAL
+    //indicateServer->unregisterApp();
+#else /* QUANTAL */
 	quitButton->hide();
 	delete quitButton;
 	disconnect(indicateServer, SIGNAL(serverDisplay()), this, SLOT(showMainWindow()));
-	disconnect(qutim_sdk_0_3::ChatLayer::instance(), SIGNAL(sessionCreated(qutim_sdk_0_3::ChatSession*)),
-	           this, SLOT(onSessionCreated(qutim_sdk_0_3::ChatSession*)));
 	qDeleteAll(sessionIndicators);
 	indicateServer->hide();
 	delete indicateServer;
+#endif /* QUANTAL */
 }
 
 void IndicatorService::onSessionCreated(qutim_sdk_0_3::ChatSession *session)
@@ -74,15 +92,33 @@ void IndicatorService::onSessionCreated(qutim_sdk_0_3::ChatSession *session)
 	if (sessionIndicators.contains(session))
 		return;
 	qutim_sdk_0_3::debug() << "List doesn't contain session. Adding indicator";
-	QIndicate::Indicator *indicator = new QIndicate::Indicator;
+
+#ifdef QUANTAL
+    Source *indicator = &indicateServer->createSourceTime(
+            QString::number(reinterpret_cast<quintptr>(session)),
+            session->getUnit()->title(),
+            QIcon(),
+            QDateTime::currentDateTime(),
+            true
+            );
+#else /* QUANTAL */
+	Source *indicator = new Source;
+#endif /* QUANTAL */
+
 	sessionIndicators.insert(session, indicator);
-	
+
 	connect(session, SIGNAL(destroyed(QObject*)), SLOT(onSessionDestroyed(QObject*)));
 	connect(session, SIGNAL(unreadChanged(const qutim_sdk_0_3::MessageList&)),
 	        SLOT(onUnreadChanged(const qutim_sdk_0_3::MessageList&)));
 	connect(session, SIGNAL(activated(bool)), SLOT(onSessionActivated(bool)));
+#ifdef QUANTAL
+    indicator->setAttention(!session->unread().isEmpty());
+    indicator->setCount(session->unread().count());
+    if (!session->unread().isEmpty())
+        indicator->setIcon(qutim_sdk_0_3::Icon("mail-unread-new"));
+#else /* QUANTAL */
 	connect(indicator, SIGNAL(display(QIndicate::Indicator*)),
-	        SLOT(onIndicatorDisplay(QIndicate::Indicator*)), Qt::QueuedConnection);
+	        SLOT(onIndicatorDisplay(MessagingMenu::Application::Source)), Qt::QueuedConnection);
 
 	QString name = session->getUnit()->title();
 	qutim_sdk_0_3::debug() << "Setting indicator name: " << name;
@@ -97,13 +133,19 @@ void IndicatorService::onSessionCreated(qutim_sdk_0_3::ChatSession *session)
 	indicator->setIndicatorProperty("subtype", "im");
 	indicator->setIndicatorProperty("sender", name);
 	indicator->show();
+#endif /* QUANTAL */
 }
 
 void IndicatorService::onSessionDestroyed(QObject *session)
 {
 	qutim_sdk_0_3::debug() << "onSessionDestroyed";
 	qutim_sdk_0_3::ChatSession *_session = static_cast<qutim_sdk_0_3::ChatSession*>(session);
-	delete sessionIndicators.take(_session);
+    Source *indicator = sessionIndicators.take(_session);
+#ifdef QUANTAL
+    indicateServer->removeSource(*indicator);
+#else /* QUANTAL */
+	delete indicator;
+#endif /* QUANTAL */
 }
 
 void IndicatorService::onUnreadChanged(const qutim_sdk_0_3::MessageList &messages)
@@ -117,10 +159,16 @@ void IndicatorService::onUnreadChanged(const qutim_sdk_0_3::MessageList &message
 		return;
 	qutim_sdk_0_3::debug() << "session exists and not active.";
 
-	QIndicate::Indicator *indicator = sessionIndicators.value(session);
+	Source *indicator = sessionIndicators.value(session);
 	if (!indicator)
 		return;
 	QDateTime time = messages.last().time();
+#ifdef QUANTAL
+    indicator->setTime(time);
+    indicator->setAttention(true);
+    indicator->setIcon(qutim_sdk_0_3::Icon("mail-unread-new"));
+    indicator->setCount(session->unread().count());
+#else /* QUANTAL */
 	indicator->setTimeProperty(time);
 	indicator->setDrawAttentionProperty(true);
 	QImage icon = qutim_sdk_0_3::Icon("mail-unread-new").pixmap(64).toImage();
@@ -128,6 +176,7 @@ void IndicatorService::onUnreadChanged(const qutim_sdk_0_3::MessageList &message
 	indicator->setCountProperty(session->unread().count());
 	// TODO: ->setIconProperty(QImage)
 	indicator->show();
+#endif /* QUANTAL */
 }
 
 void IndicatorService::onAccountCreated(qutim_sdk_0_3::Account *)
@@ -150,20 +199,33 @@ void IndicatorService::onSessionActivated(bool active)
 	qutim_sdk_0_3::ChatSession *session = qobject_cast<qutim_sdk_0_3::ChatSession*>(sender());
 	if (!session)
 		return;
-	QIndicate::Indicator *indicator = sessionIndicators.value(session);
+	Source *indicator = sessionIndicators.value(session);
 	if (!indicator)
 		return;
+#ifdef QUANTAL
+    indicator->setTime(QDateTime::currentDateTime());
+    indicator->setAttention(false);
+    indicator->setCount(session->unread().count());
+    indicator->setIcon(QIcon());
+#else /* QUANTAL */
 	indicator->setTimeProperty(QDateTime::currentDateTime());
 	indicator->setDrawAttentionProperty(false);
 	indicator->setCountProperty(session->unread().count());
 	indicator->setIconProperty(QImage());
 	//indicator->hide();
+#endif /* QUANTAL */
 }
 
-void IndicatorService::onIndicatorDisplay(QIndicate::Indicator* indicator)
+void IndicatorService::onIndicatorDisplay(SourceRef indicator)
 {
 	qutim_sdk_0_3::debug() << "onIndicatorDisplay";
+#ifdef QUANTAL
+    if (indicator.getLabel() == QT_TRANSLATE_NOOP("Plugin", "Close qutIM"))
+        qApp->quit();
+	qutim_sdk_0_3::ChatSession* session = sessionIndicators.key(&indicator);
+#else /* QUANTAL */
 	qutim_sdk_0_3::ChatSession* session = sessionIndicators.key(indicator);
+#endif /* QUANTAL */
 	if (!sessionIndicators.contains(session))
 		return;
 	session->activate();

--- a/plugins/indicator/src/indicatorservice.h
+++ b/plugins/indicator/src/indicatorservice.h
@@ -25,19 +25,33 @@
 #ifndef INDICATORSERVICE_23DW9H42
 #define INDICATORSERVICE_23DW9H42
 
+#define QUTIM_DESKTOP_BASENAME "qutim.desktop"
 #ifndef DESKTOPDIR
 # define DESKTOPDIR ""
 #endif
-#define QUTIM_DESKTOP_FILE DESKTOPDIR "/qutim.desktop"
+#define QUTIM_DESKTOP_FILE DESKTOPDIR "/" QUTIM_DESKTOP_BASENAME
 
+#ifdef QUANTAL
+#include <messaging-menu-qt/messaging-menu.hpp>
+#else /* QUANTAL */
 #include <qindicateindicator.h>
 #include <qindicateserver.h>
+#endif
 
 #include <qutim/chatsession.h>
 #include <qutim/account.h>
 #include <qutim/protocol.h>
 
-typedef QHash<qutim_sdk_0_3::ChatSession*, QIndicate::Indicator*> HashIndicator;
+#ifdef QUANTAL
+typedef MessagingMenu::Application::Source Source;
+typedef Source& SourceRef;
+typedef MessagingMenu::Application Server;
+#else /* QUANTAL */
+typedef QIndicate::Indicator Source;
+typedef Source* SourceRef;
+typedef QIndicate::Server Server;
+#endif
+typedef QHash<qutim_sdk_0_3::ChatSession*, Source*> HashIndicator;
 
 class IndicatorService : public qutim_sdk_0_3::MenuController
 {
@@ -57,13 +71,17 @@ protected slots:
 	void loadSettings();
 	/* Indicator stuff */
 	void onSessionActivated(bool);
+#ifdef QUANTAL
+	void onIndicatorDisplay(MessagingMenu::Application::Source&);
+#else /* QUANTAL */
 	void onIndicatorDisplay(QIndicate::Indicator*);
+#endif /* QUANTAL */
 	void showMainWindow();
 private:
 	HashIndicator sessionIndicators;
 	QString desktopName;
-	QIndicate::Server* indicateServer;
-	QIndicate::Indicator *quitButton;
+	Server *indicateServer;
+	Source *quitButton;
 };
 
 #endif /* end of include guard: INDICATORSERVICE_23DW9H42 */


### PR DESCRIPTION
Patch wihich uses libmessaging-menu-qt library under Ubuntu 12.10 to make indicators work.
