### PR TITLE
Fixed broken status changing

### DIFF
--- a/src/lib/qutim/account.cpp
+++ b/src/lib/qutim/account.cpp
@@ -184,6 +184,7 @@ void AccountPrivate::updateStatus()
 		break;
 	case Account::Connected:
 	case Account::Disconnecting:
+		q_func()->doStatusChange(userStatus);
 		setStatus(userStatus);
 		break;
 	}

--- a/src/plugins/generic/idledetector/idle.cpp
+++ b/src/plugins/generic/idledetector/idle.cpp
@@ -76,7 +76,7 @@ bool Idle::isActive() const
 
 bool Idle::usingPlatform() const
 {
-	return (platform ? true: false);
+	return (platform ? true : false);
 }
 
 void Idle::start()
@@ -101,9 +101,9 @@ void Idle::stop()
 int Idle::secondsIdle()
 {
 	int i;
-	if (platform)
+	if (platform) {
 		i = platform->secondsIdle();
-	else {
+	} else {
 		QPoint curMousePos = QCursor::pos();
 		QDateTime curDateTime = QDateTime::currentDateTime();
 		if(d->lastMousePos != curMousePos) {
@@ -131,12 +131,13 @@ int Idle::secondsIdle()
 
 	// how long have we been idle?
 	int idleTime = d->startTime.secsTo(QDateTime::currentDateTime());
+
 	return idleTime;
 }
 
 void Idle::doCheck()
 {
-	secondsIdle(secondsIdle());
+	emit secondsIdle(secondsIdle());
 }
 }
 

--- a/src/plugins/generic/idlestatuschanger/idle-global.h
+++ b/src/plugins/generic/idlestatuschanger/idle-global.h
@@ -22,9 +22,6 @@
 ** $QUTIM_END_LICENSE$
 **
 ****************************************************************************/
-#define AWAY_DEF_SECS 180 // 3 mins
-#define NA_DEF_SECS 600 // 10 mins
-#define AA_CONFIG_GROUP "auto-away"
 
 namespace Core{
 class IdleStatusChanger;

--- a/src/plugins/generic/idlestatuschanger/idlestatuschanger.cpp
+++ b/src/plugins/generic/idlestatuschanger/idlestatuschanger.cpp
@@ -104,8 +104,8 @@ void IdleStatusChanger::reloadSettings()
 	conf.beginGroup("auto-away");
 	m_awayEnabled = conf.value("away-enabled", true);
 	m_naEnabled   = conf.value("na-enabled",   true);
-	m_awaySecs = conf.value("away-secs", 180); // 3*60 -- 3 minutes
-	m_naSecs   = conf.value("na-secs", 600); // 10*60 -- 10 minutes
+	m_awaySecs = conf.value("away-secs", 3*60); // 3 minutes
+	m_naSecs   = conf.value("na-secs", 10*60); // 10 minutes
 	m_awayStatus.setText(conf.value("away-text", ""));
 	m_naStatus.  setText(conf.value("na-text",   ""));
 }

--- a/src/plugins/generic/idlestatuschanger/idlestatuschanger.cpp
+++ b/src/plugins/generic/idlestatuschanger/idlestatuschanger.cpp
@@ -69,7 +69,7 @@ void IdleStatusChanger::refillAccounts()
 
 void IdleStatusChanger::onIdle(int secs)
 {
-	if ((m_awayEnabled?m_state == Away:1)
+	if ((m_awayEnabled ? m_state == Away : 1)
 			&& secs > m_naSecs
 			&& m_naEnabled) {
 		refillAccounts();
@@ -100,11 +100,12 @@ void IdleStatusChanger::onIdle(int secs)
 
 void IdleStatusChanger::reloadSettings()
 {
-	Config conf(AA_CONFIG_GROUP);
+	Config conf;
+	conf.beginGroup("auto-away");
 	m_awayEnabled = conf.value("away-enabled", true);
 	m_naEnabled   = conf.value("na-enabled",   true);
-	m_awaySecs = conf.value("away-secs", AWAY_DEF_SECS);
-	m_naSecs   = conf.value("na-secs",   NA_DEF_SECS);
+	m_awaySecs = conf.value("away-secs", 180); // 3*60 -- 3 minutes
+	m_naSecs   = conf.value("na-secs", 600); // 10*60 -- 10 minutes
 	m_awayStatus.setText(conf.value("away-text", ""));
 	m_naStatus.  setText(conf.value("na-text",   ""));
 }


### PR DESCRIPTION
This fix started from locating bug at idledetector, but after some research I found that status changing was broken at all (Only if you changing Online -> Online statuses, for example, Online -> Away).